### PR TITLE
Lower bound on ghc-exactprint was wrong, added stack.yaml

### DIFF
--- a/hgrep.cabal
+++ b/hgrep.cabal
@@ -44,7 +44,7 @@ library
                      base                           >= 4.9           && < 4.11
                    , ansi-terminal                  >= 0.6.3         && < 0.8
                    , ghc                            >= 7.10.2        && < 8.3
-                   , ghc-exactprint                 >= 0.5           && < 0.6
+                   , ghc-exactprint                 >= 0.5.4.0       && < 0.6
                    , hscolour                       >= 1.24          && < 1.25
                    , lens                           >= 4.15          && < 4.16
                    , template-haskell               >= 2.11          && < 2.13

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,12 @@
+resolver: lts-8.24
+
+packages:
+- .
+
+extra-deps:
+  - ghc-exactprint-0.5.5.0
+  - transformers-bifunctors-0.1
+
+flags: {}
+
+extra-package-dbs: []


### PR DESCRIPTION
```
[4 of 7] Compiling Language.Haskell.HGrep.Internal.Data ( src/Language/Haskell/HGrep/Internal/Data.hs, .stack-work/dist/x86_64-linux/Cabal-1.24.2.0/build/Language/Haskell/HGrep/Internal/Data.o )
               
/home/callen/work/hgrep/src/Language/Haskell/HGrep/Internal/Data.hs:19:1: error:
    Failed to load interface for ‘Language.Haskell.GHC.ExactPrint.Annotater’
    Perhaps you meant
      Language.Haskell.GHC.ExactPrint.Annotate (from ghc-exactprint-0.5.3.1)
      Language.Haskell.GHC.ExactPrint.Delta (from ghc-exactprint-0.5.3.1)
      Language.Haskell.GHC.ExactPrint.Pretty (from ghc-exactprint-0.5.3.1)
    Use -v to see a list of the files searched for.
Completed 13 action(s).
```

![screenshot from 2017-10-03 11-39-01](https://user-images.githubusercontent.com/320177/31137014-76ad032c-a82f-11e7-9984-1b09f01ac167.png)
