### PR TITLE
Add the stack-work directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cabal-dev
 cabal.sandbox.config
 /tmp
 /gen
+.stack-work


### PR DESCRIPTION
I suppose helps towards #9. I was able to run with `stack build && stack exec hgrep` from a fresh clone. Stack uses the `.stack-work` directory to keep local build artifacts so I've added that to the gitignore.
(Nice project btw, the parser doesn't like projects like the PureScript compiler which use a lot of `default-extensions` in the cabal file but I suppose that's a separate issue 😄 )