### PR TITLE
Update README with requirements and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,26 @@ nix-env -i pcre
 #### Stack
 
 ```
-git clone https://github.com/timhumphries/hgrep.git
+git clone https://github.com/thumphries/hgrep.git
 cd !$
 stack install
+```
+
+
+#### Cabal
+
+```
+git clone https://github.com/thumphries/hgrep.git
+cd !$
+cabal new-build
+```
+
+#### Mafia
+
+```
+git clone https://github.com/thumphries/hgrep.git
+cd !$
+mafia build
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,41 @@ An expression can be one of
 Each file will be parsed and searched. Results will be printed to the
 console, with syntax highlighting where possible.
 
+### Requirements
+
+You can use `cabal` or `stack` to install, but you may need `libpcre`. In case you don't have it:
+
+#### Ubuntu
+
+```bash
+sudo apt update
+sudo apt install libpcre3-dev
+```
+
+#### Fedora
+
+```
+sudo dnf update
+sudo dnf install pcre-devel
+```
+
+#### NixOS / Nix Package Manager
+
+```
+nix-env -i pcre
+```
+
+### Install
+
+#### Stack
+
+```
+git clone https://github.com/timhumphries/hgrep.git
+cd !$
+stack install
+```
+
+
 ### Searching for top-level expressions
 
 ```haskell


### PR DESCRIPTION
Mac OS X seems fine (i.e. has pcre support to begin with), have tested
with Ubuntu and Fedora so package names should be correct. Have not
directly tested with NixOS / `nix`, but considering that `pcre` is the
only package that comes up with `nix-env -qaP pcre`, I'm going to assume
that's fine.

I'm not quite accustomed to cabal, so I'm not sure what to fill in below
the `stack` installation, but `stack [build|install]` seem fine when the
appropriate deps are installed.

This should hopefully resolve #26 by informing users on platforms that don't have `libpcre` by default.