### PR TITLE
Remove empty lines before printing source (numbered or otherwise)

### DIFF
--- a/src/Language/Haskell/HGrep/Prelude.hs
+++ b/src/Language/Haskell/HGrep/Prelude.hs
@@ -70,7 +70,6 @@ module Language.Haskell.HGrep.Prelude (
   , curry
   , uncurry
 
-
   -- * Typeclasses
   -- ** Enum
   , Enum (..)
@@ -97,7 +96,6 @@ module Language.Haskell.HGrep.Prelude (
   , Traversable (..)
   , for
   , traverse_
-
 
   -- * Combinators
   , id

--- a/src/Language/Haskell/HGrep/Prelude.hs
+++ b/src/Language/Haskell/HGrep/Prelude.hs
@@ -109,10 +109,6 @@ module Language.Haskell.HGrep.Prelude (
   , on
   , seq
 
-  -- * Predicates
-  -- ** Char
-  , isSpace
-
   -- * System
   -- ** IO
   , IO
@@ -159,7 +155,6 @@ import           Data.Bool as Bool (
          )
 import           Data.Char as Char (
            Char
-         , isSpace
          )
 import           Data.Either as Either (
            Either (..)

--- a/src/Language/Haskell/HGrep/Prelude.hs
+++ b/src/Language/Haskell/HGrep/Prelude.hs
@@ -70,6 +70,7 @@ module Language.Haskell.HGrep.Prelude (
   , curry
   , uncurry
 
+
   -- * Typeclasses
   -- ** Enum
   , Enum (..)
@@ -87,6 +88,7 @@ module Language.Haskell.HGrep.Prelude (
   -- ** Foldable
   , Foldable (..)
   , for_
+  , all
   -- ** Ord
   , Ord (..)
   , Ordering (..)
@@ -108,6 +110,10 @@ module Language.Haskell.HGrep.Prelude (
   , fix
   , on
   , seq
+
+  -- * Predicates
+  -- ** Char
+  , isSpace
 
   -- * System
   -- ** IO
@@ -155,6 +161,7 @@ import           Data.Bool as Bool (
          )
 import           Data.Char as Char (
            Char
+         , isSpace
          )
 import           Data.Either as Either (
            Either (..)
@@ -165,6 +172,7 @@ import           Data.Foldable as Foldable (
          , asum
          , traverse_
          , for_
+         , all
          )
 import           Data.Function as Function (
            id

--- a/src/Language/Haskell/HGrep/Print.hs
+++ b/src/Language/Haskell/HGrep/Print.hs
@@ -9,7 +9,6 @@ module Language.Haskell.HGrep.Print (
 
 import qualified Data.List as L
 import qualified Data.Map  as Map
-import Data.Char (isSpace)
 
 import qualified Language.Haskell.GHC.ExactPrint as EP
 import qualified Language.Haskell.GHC.ExactPrint.Types as EP
@@ -63,7 +62,7 @@ printSearchResult (PrintOpts co lno) (SearchResult anns ast) =
     wholeSrc = EP.exactPrint ast anns
 
     nonEmptySrc :: [[Char]]
-    nonEmptySrc = L.filter (not . all isSpace) $ L.lines wholeSrc
+    (_, nonEmptySrc) = L.span null $ L.lines wholeSrc
 
     nonNumberedSrc = L.unlines nonEmptySrc
 

--- a/src/Language/Haskell/HGrep/Print.hs
+++ b/src/Language/Haskell/HGrep/Print.hs
@@ -36,29 +36,15 @@ printParseError (ParseError (loc, msg)) =
 printSearchResult :: PrintOpts -> SearchResult -> [Char]
 printSearchResult (PrintOpts co lno) (SearchResult anns ast) =
   -- Get the start position of the comment before search result
-  let annsPairs      = Map.toList anns
-      targetAnnPairs = L.filter (isSameLoc .fst) annsPairs
-      resLoc         = getSpanStartLine resSpan
-      startLineNum   =
-        case targetAnnPairs of
-          []             -> resLoc
-          ((_, ann) : _) ->
-            case EP.annPriorComments ann of
-              []                 -> resLoc
-              ((comment, _) : _) -> getSpanStartLine $ EP.commentIdentifier comment
-      nonNumberedSrc = L.unlines src
-      numberedSrc = printWithLineNums startLineNum in
-    colorize $ case lno of
+  colorize $ case lno of
       PrintLineNums -> numberedSrc
       NoLineNums    -> nonNumberedSrc
   where
     colorize :: [Char] -> [Char]
     colorize anySrc =
       case co of
-        DefaultColours ->
-          hscolour anySrc
-        NoColours ->
-          anySrc
+        DefaultColours -> hscolour anySrc
+        NoColours      -> anySrc
 
     resSpan :: SrcLoc.SrcSpan
     resSpan = SrcLoc.getLoc ast
@@ -77,14 +63,29 @@ printSearchResult (PrintOpts co lno) (SearchResult anns ast) =
     wholeSrc :: [Char]
     wholeSrc = EP.exactPrint ast anns
 
-    src :: [[Char]]
-    (_, src) = L.span (\s -> null s || all isSpace s) $ L.lines wholeSrc
+    nonEmptySrc :: [[Char]]
+    nonEmptySrc = L.filter (not . all isSpace) $ L.lines wholeSrc
+
+    nonNumberedSrc = L.unlines nonEmptySrc
 
     -- Doesn't prepent locations when there is no start line number
     printWithLineNums :: Maybe Int -> [Char]
-    printWithLineNums Nothing      = L.unlines src
+    printWithLineNums Nothing      = nonNumberedSrc
     printWithLineNums (Just start) =
-      L.unlines $ L.zipWith prependLineNum [start..] src
+      L.unlines $ L.zipWith prependLineNum [start..] nonEmptySrc
+
+    annsPairs      = Map.toList anns
+    targetAnnPairs = L.filter (isSameLoc .fst) annsPairs
+    resLoc         = getSpanStartLine resSpan
+    startLineNum   =
+        case targetAnnPairs of
+          []             -> resLoc
+          ((_, ann) : _) ->
+            case EP.annPriorComments ann of
+              []                 -> resLoc
+              ((comment, _) : _) -> getSpanStartLine $ EP.commentIdentifier comment
+
+    numberedSrc = printWithLineNums startLineNum
 
     -- Adds line numbers at the start of each line
     prependLineNum :: Int -> [Char] -> [Char]

--- a/src/Language/Haskell/HGrep/Print.hs
+++ b/src/Language/Haskell/HGrep/Print.hs
@@ -9,8 +9,6 @@ module Language.Haskell.HGrep.Print (
 
 import qualified Data.List as L
 import qualified Data.Map  as Map
-import Data.Char (isSpace)
-import Data.Foldable (all)
 
 import qualified Language.Haskell.GHC.ExactPrint as EP
 import qualified Language.Haskell.GHC.ExactPrint.Types as EP

--- a/src/Language/Haskell/HGrep/Print.hs
+++ b/src/Language/Haskell/HGrep/Print.hs
@@ -9,6 +9,7 @@ module Language.Haskell.HGrep.Print (
 
 import qualified Data.List as L
 import qualified Data.Map  as Map
+import Data.Char (isSpace)
 
 import qualified Language.Haskell.GHC.ExactPrint as EP
 import qualified Language.Haskell.GHC.ExactPrint.Types as EP


### PR DESCRIPTION
Should resolve #18. This trashes the empty lines instead of merging them
back into the results. This does not include comments, e.g.

```haskell
η hgrep main main/hgrep.hs
main/hgrep.hs:18:1-13
17  -- A comment!
18  main :: IO ()
```

Examples:

```haskell
~/misc/hgrep
η hgrep -n main main/hgrep.hs
main/hgrep.hs:17:1-13
main :: IO ()

main/hgrep.hs:(18,1)-(32,31)
main = do
  IO.hSetBuffering IO.stdout IO.LineBuffering
  IO.hSetBuffering IO.stderr IO.LineBuffering
  opts <- parseOpts
  colour <- detectColour
  case parseQuery (cmdQuery opts) (cmdRegex opts) of
    Left er -> do
      IO.hPutStrLn IO.stderr er
      exitWith (ExitFailure 2)
    Right q -> do
      found <-
        fmap sum $
          for (cmdFiles opts) $ \fp ->
            hgrep (HGrep.PrintOpts colour (cmdLineNums opts)) q fp
      exitWith (exitCode found)

~/misc/hgrep
η hgrep main main/hgrep.hs
main/hgrep.hs:17:1-13
17  main :: IO ()

main/hgrep.hs:(18,1)-(32,31)
18  main = do
19    IO.hSetBuffering IO.stdout IO.LineBuffering
20    IO.hSetBuffering IO.stderr IO.LineBuffering
21    opts <- parseOpts
22    colour <- detectColour
23    case parseQuery (cmdQuery opts) (cmdRegex opts) of
24      Left er -> do
25        IO.hPutStrLn IO.stderr er
26        exitWith (ExitFailure 2)
27      Right q -> do
28        found <-
29          fmap sum $
30            for (cmdFiles opts) $ \fp ->
31              hgrep (HGrep.PrintOpts colour (cmdLineNums opts)) q fp
32        exitWith (exitCode found)
```