### PR TITLE
Merge adjacent SrcSpans (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ cabal.sandbox.config
 /tmp
 /gen
 .stack-work
+
+*~

--- a/hgrep.cabal
+++ b/hgrep.cabal
@@ -62,3 +62,4 @@ library
                      Language.Haskell.HGrep.Internal.Data
                      Language.Haskell.HGrep.Internal.Lens
                      Language.Haskell.HGrep.Internal.Lens.Rules
+                     Language.Haskell.HGrep.Internal.Print

--- a/src/Language/Haskell/HGrep.hs
+++ b/src/Language/Haskell/HGrep.hs
@@ -25,6 +25,7 @@ module Language.Haskell.HGrep (
 
 
 import           Language.Haskell.HGrep.Internal.Data
+import           Language.Haskell.HGrep.Internal.Print
 import           Language.Haskell.HGrep.Prelude
 import qualified Language.Haskell.HGrep.Print as HP
 import qualified Language.Haskell.HGrep.Query as HQ
@@ -33,7 +34,6 @@ import qualified Language.Haskell.GHC.ExactPrint as EP
 
 import qualified System.IO as IO
 
-import           GHC.Num ((+))
 import qualified SrcLoc
 
 
@@ -47,41 +47,41 @@ queryModule q src =
     (HQ.findTypeDecl q src)
     (HQ.findValueDecl q src)
 
-type TextWithLocation = ([Char], SrcLoc.SrcSpan)
-
 printResults :: PrintOpts -> [SearchResult] -> IO ()
 printResults opts results = do
-  let printedResult = fmap printWithLocation results
+  let printedResult = fmap (printWithLocation opts) results
   for_ (foldAdjacent printedResult) $ \(textResult, span) -> do
-    IO.hPutStr   IO.stdout (HP.printSearchResultLocation opts span)
+    IO.hPutStr   IO.stdout (printSrcSpan opts span)
     IO.hPutStrLn IO.stdout textResult
- where
-  printWithLocation :: SearchResult -> TextWithLocation
-  printWithLocation result@(SearchResult _ loc) =
-    (HP.printSearchResult opts result, SrcLoc.getLoc loc)
 
-  foldAdjacent :: [TextWithLocation] -> [TextWithLocation]
-  foldAdjacent []                              = []
-  foldAdjacent [result]                        = [result]
-  foldAdjacent (firstResult:secondResult:rest) =
-    case (firstResult, secondResult) of
-      ((firstText, firstSpan), (secondText, secondSpan)) ->
-        case mergedLocs firstSpan secondSpan of
-          Nothing   ->
-            firstResult : foldAdjacent (secondResult:rest)
-          Just span ->
-            foldAdjacent $ (firstText <> secondText, span) : rest
+type TextWithLocation = ([Char], SrcLoc.SrcSpan)
 
-  mergedLocs :: SrcLoc.SrcSpan -> SrcLoc.SrcSpan -> Maybe SrcLoc.SrcSpan
-  mergedLocs span1 span2
-    | areAdjacentSpans span1 span2 = Just $ SrcLoc.combineSrcSpans span1 span2
-    | otherwise                    = Nothing
+printWithLocation :: PrintOpts -> SearchResult -> TextWithLocation
+printWithLocation opts result@(SearchResult _ loc) =
+  (HP.printSearchResult opts result, SrcLoc.getLoc loc)
 
-  areAdjacentSpans :: SrcLoc.SrcSpan -> SrcLoc.SrcSpan -> Bool
-  areAdjacentSpans span1 span2 =
-    areAdjacentLocs (SrcLoc.srcSpanEnd span1) (SrcLoc.srcSpanStart span2)
+foldAdjacent :: [TextWithLocation] -> [TextWithLocation]
+foldAdjacent []                              = []
+foldAdjacent [result]                        = [result]
+foldAdjacent (firstResult:secondResult:rest) =
+  case (firstResult, secondResult) of
+    ((firstText, firstSpan), (secondText, secondSpan)) ->
+      case mergedLocs firstSpan secondSpan of
+        Nothing   ->
+          firstResult : foldAdjacent (secondResult:rest)
+        Just span ->
+          foldAdjacent $ (firstText <> secondText, span) : rest
 
-  areAdjacentLocs :: SrcLoc.SrcLoc -> SrcLoc.SrcLoc -> Bool
-  areAdjacentLocs (SrcLoc.RealSrcLoc loc1) (SrcLoc.RealSrcLoc loc2) =
-    SrcLoc.srcLocLine loc1 + 1 == SrcLoc.srcLocLine loc2
-  areAdjacentLocs _ _ = False
+mergedLocs :: SrcLoc.SrcSpan -> SrcLoc.SrcSpan -> Maybe SrcLoc.SrcSpan
+mergedLocs span1 span2
+  | areAdjacentSpans span1 span2 = Just $ SrcLoc.combineSrcSpans span1 span2
+  | otherwise                    = Nothing
+
+areAdjacentSpans :: SrcLoc.SrcSpan -> SrcLoc.SrcSpan -> Bool
+areAdjacentSpans span1 span2 =
+  areAdjacentLocs (SrcLoc.srcSpanEnd span1) (SrcLoc.srcSpanStart span2)
+
+areAdjacentLocs :: SrcLoc.SrcLoc -> SrcLoc.SrcLoc -> Bool
+areAdjacentLocs (SrcLoc.RealSrcLoc loc1) (SrcLoc.RealSrcLoc loc2) =
+  SrcLoc.srcLocLine loc1 + 1 == SrcLoc.srcLocLine loc2
+areAdjacentLocs _ _ = False

--- a/src/Language/Haskell/HGrep.hs
+++ b/src/Language/Haskell/HGrep.hs
@@ -25,13 +25,16 @@ module Language.Haskell.HGrep (
 
 
 import           Language.Haskell.HGrep.Internal.Data
+import           Language.Haskell.HGrep.Prelude
 import qualified Language.Haskell.HGrep.Print as HP
 import qualified Language.Haskell.HGrep.Query as HQ
-import           Language.Haskell.HGrep.Prelude
 
 import qualified Language.Haskell.GHC.ExactPrint as EP
 
 import qualified System.IO as IO
+
+import           GHC.Num ((+))
+import qualified SrcLoc
 
 
 parseModule :: FilePath -> IO (Either ParseError ParsedSource)
@@ -44,8 +47,41 @@ queryModule q src =
     (HQ.findTypeDecl q src)
     (HQ.findValueDecl q src)
 
+type TextWithLocation = ([Char], SrcLoc.SrcSpan)
+
 printResults :: PrintOpts -> [SearchResult] -> IO ()
-printResults opts results =
-  for_ results $ \res -> do
-    IO.hPutStr IO.stdout (HP.printSearchResultLocation opts res)
-    IO.hPutStrLn IO.stdout (HP.printSearchResult opts res)
+printResults opts results = do
+  let printedResult = fmap printWithLocation results
+  for_ (foldAdjacent printedResult) $ \(textResult, span) -> do
+    IO.hPutStr   IO.stdout (HP.printSearchResultLocation opts span)
+    IO.hPutStrLn IO.stdout textResult
+ where
+  printWithLocation :: SearchResult -> TextWithLocation
+  printWithLocation result@(SearchResult _ loc) =
+    (HP.printSearchResult opts result, SrcLoc.getLoc loc)
+
+  foldAdjacent :: [TextWithLocation] -> [TextWithLocation]
+  foldAdjacent []                              = []
+  foldAdjacent [result]                        = [result]
+  foldAdjacent (firstResult:secondResult:rest) =
+    case (firstResult, secondResult) of
+      ((firstText, firstSpan), (secondText, secondSpan)) ->
+        case mergedLocs firstSpan secondSpan of
+          Nothing   ->
+            firstResult : foldAdjacent (secondResult:rest)
+          Just span ->
+            foldAdjacent $ (firstText <> secondText, span) : rest
+
+  mergedLocs :: SrcLoc.SrcSpan -> SrcLoc.SrcSpan -> Maybe SrcLoc.SrcSpan
+  mergedLocs span1 span2
+    | areAdjacentSpans span1 span2 = Just $ SrcLoc.combineSrcSpans span1 span2
+    | otherwise                    = Nothing
+
+  areAdjacentSpans :: SrcLoc.SrcSpan -> SrcLoc.SrcSpan -> Bool
+  areAdjacentSpans span1 span2 =
+    areAdjacentLocs (SrcLoc.srcSpanEnd span1) (SrcLoc.srcSpanStart span2)
+
+  areAdjacentLocs :: SrcLoc.SrcLoc -> SrcLoc.SrcLoc -> Bool
+  areAdjacentLocs (SrcLoc.RealSrcLoc loc1) (SrcLoc.RealSrcLoc loc2) =
+    SrcLoc.srcLocLine loc1 + 1 == SrcLoc.srcLocLine loc2
+  areAdjacentLocs _ _ = False

--- a/src/Language/Haskell/HGrep/Internal/Print.hs
+++ b/src/Language/Haskell/HGrep/Internal/Print.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Internal private functions for 'Language.Haskell.HGrep.Print'.
+
+module Language.Haskell.HGrep.Internal.Print (
+    printSrcSpan
+  , unsafePpr
+  ) where
+
+import qualified Data.List as L
+
+import           Language.Haskell.HGrep.Internal.Data
+import           Language.Haskell.HGrep.Prelude
+
+import qualified Outputable
+import qualified System.Console.ANSI as ANSI
+import qualified SrcLoc
+
+printSrcSpan :: PrintOpts -> SrcLoc.SrcSpan -> [Char]
+printSrcSpan (PrintOpts co _) span =
+  let loc = chomp (unsafePpr span) in
+    case co of
+      DefaultColours ->
+        ansiLocationFormat <> loc <> ansiReset
+      NoColours ->
+        loc
+
+ansiLocationFormat :: [Char]
+ansiLocationFormat =
+  ANSI.setSGRCode [
+      ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green
+    , ANSI.SetUnderlining ANSI.SingleUnderline
+    ]
+
+ansiReset :: [Char]
+ansiReset =
+  ANSI.setSGRCode []
+
+unsafePpr :: Outputable.Outputable o => o -> [Char]
+unsafePpr =
+  Outputable.showSDocUnsafe . Outputable.ppr
+
+chomp :: [Char] -> [Char]
+chomp =
+  L.unlines . L.lines

--- a/src/Language/Haskell/HGrep/Prelude.hs
+++ b/src/Language/Haskell/HGrep/Prelude.hs
@@ -73,6 +73,8 @@ module Language.Haskell.HGrep.Prelude (
   -- * Typeclasses
   -- ** Enum
   , Enum (..)
+  -- ** Num
+  , Num (..)
   -- ** Eq
   , Eq (..)
   -- ** Read
@@ -232,6 +234,7 @@ import           GHC.Stack (HasCallStack)
 
 import           Prelude as Prelude (
            Enum (..)
+         , Num (..)
          , Integer
          , seq
          , ($!)

--- a/src/Language/Haskell/HGrep/Print.hs
+++ b/src/Language/Haskell/HGrep/Print.hs
@@ -8,7 +8,7 @@ module Language.Haskell.HGrep.Print (
 
 
 import qualified Data.List as L
-import qualified Data.Map  as Map
+import qualified Data.Map as Map
 
 import qualified Language.Haskell.GHC.ExactPrint as EP
 import qualified Language.Haskell.GHC.ExactPrint.Types as EP
@@ -87,9 +87,9 @@ printSearchResult (PrintOpts co lno) (SearchResult anns ast) =
     prependLineNum :: Int -> [Char] -> [Char]
     prependLineNum i l = show i <> "  " <> l
 
-printSearchResultLocation :: PrintOpts -> SearchResult -> [Char]
-printSearchResultLocation (PrintOpts co _) (SearchResult _anns ast) =
-  let loc = chomp (unsafePpr (SrcLoc.getLoc ast)) in
+printSearchResultLocation :: PrintOpts -> SrcLoc.SrcSpan -> [Char]
+printSearchResultLocation (PrintOpts co _) span =
+  let loc = chomp (unsafePpr span) in
     case co of
       DefaultColours ->
         ansiLocationFormat <> loc <> ansiReset

--- a/src/Language/Haskell/HGrep/Print.hs
+++ b/src/Language/Haskell/HGrep/Print.hs
@@ -16,11 +16,9 @@ import qualified Language.Haskell.HsColour as HsColour
 import qualified Language.Haskell.HsColour.Colourise as HsColour
 
 import           Language.Haskell.HGrep.Internal.Data
+import           Language.Haskell.HGrep.Internal.Print
 import           Language.Haskell.HGrep.Prelude
 
-import qualified System.Console.ANSI as ANSI
-
-import qualified Outputable
 import qualified SrcLoc
 
 
@@ -87,34 +85,10 @@ printSearchResult (PrintOpts co lno) (SearchResult anns ast) =
     prependLineNum :: Int -> [Char] -> [Char]
     prependLineNum i l = show i <> "  " <> l
 
-printSearchResultLocation :: PrintOpts -> SrcLoc.SrcSpan -> [Char]
-printSearchResultLocation (PrintOpts co _) span =
-  let loc = chomp (unsafePpr span) in
-    case co of
-      DefaultColours ->
-        ansiLocationFormat <> loc <> ansiReset
-      NoColours ->
-        loc
-
-ansiLocationFormat :: [Char]
-ansiLocationFormat =
-  ANSI.setSGRCode [
-      ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green
-    , ANSI.SetUnderlining ANSI.SingleUnderline
-    ]
-
-ansiReset :: [Char]
-ansiReset =
-  ANSI.setSGRCode []
+printSearchResultLocation :: PrintOpts -> SearchResult -> [Char]
+printSearchResultLocation opts (SearchResult _anns ast) =
+  printSrcSpan opts (SrcLoc.getLoc ast)
 
 hscolour :: [Char] -> [Char]
 hscolour =
   HsColour.hscolour HsColour.TTY HsColour.defaultColourPrefs False False "" False
-
-unsafePpr :: Outputable.Outputable o => o -> [Char]
-unsafePpr =
-  Outputable.showSDocUnsafe . Outputable.ppr
-
-chomp :: [Char] -> [Char]
-chomp =
-  L.unlines . L.lines


### PR DESCRIPTION
Now search results combined with empty lines, like this:

```haskell
$ hgrep main main/hgrep.hs 
main/hgrep.hs:(17,1)-(32,31)



17  main :: IO ()

18  main = do
19    IO.hSetBuffering IO.stdout IO.LineBuffering
20    IO.hSetBuffering IO.stderr IO.LineBuffering
21    opts <- parseOpts
22    colour <- detectColour
23    case parseQuery (cmdQuery opts) (cmdRegex opts) of
24      Left er -> do
25        IO.hPutStrLn IO.stderr er
26        exitWith (ExitFailure 2)
27      Right q -> do
28        found <-
29          fmap sum $
30            for (cmdFiles opts) $ \fp ->
31              hgrep (HGrep.PrintOpts colour (cmdLineNums opts)) q fp
32        exitWith (exitCode found)
```

But after PR #32 is merged this won't be a problem.