### PR TITLE
Start publishing builds to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ cache:
 matrix:
   include:
   # The Cabal builds.
-  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 PUBLISH=true
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  - env: BUILD=cabal GHCVER=8.2.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 PUBLISH=true
+  - env: BUILD=cabal GHCVER=8.2.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.2.1"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  - env: BUILD=cabal GHCVER=8.2.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=8.2.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 PUBLISH=true
     compiler: ": #GHC 8.2.1"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
@@ -35,7 +35,7 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Build on macOS in addition to Linux
-  - env: BUILD=stack ARGS=""
+  - env: BUILD=stack ARGS="" PUBLISH=true
     compiler: ": #stack default osx"
     os: osx
 
@@ -126,3 +126,15 @@ script:
       ;;
   esac
   set +ex
+
+before_deploy:
+# Install awscli for deploy jobs
+- pip install --user awscli
+- PATH=$HOME/.local/bin:$HOME/Library/Python/2.7/bin:$PATH
+
+deploy:
+  provider: script
+  script: bin/travis_publish
+  skip_cleanup: true
+  on:
+    branch: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Version 0.2 (unreleased)
+## Version 0.2 (2017-10-08)
 
 - Print line numbers (optionally disabled with `--no-numbers`)
+- Combine adjacent declarations when printing
 - Add exception handling for ExactPrint exceptions (Bug fix)
 
 ## Version 0.1 (2017-10-04)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@ order:
 - Ryan James Spencer ([@justanotherdot](https://github.com/justanotherdot))
 - Eoin Houlihan ([@houli](https://github.com/houli))
 - Bobby Rauchenberg ([@bobbyrauchenberg](https://github.com/bobbyrauchenberg))
+- Dmitry Kovanikov ([@ChShersh](https://github.com/ChShersh))

--- a/bin/travis_publish
+++ b/bin/travis_publish
@@ -1,0 +1,37 @@
+#!/bin/sh -exu
+
+PROJECT=hgrep
+BINARIES=hgrep
+
+if [ "${PUBLISH:-}" = "true" ]; then
+
+  export AWS_ACCESS_KEY_ID=${PUBLISH_KEY}
+  export AWS_SECRET_ACCESS_KEY=${PUBLISH_SECRET}
+  export AWS_DEFAULT_REGION=${PUBLISH_REGION}
+
+  BUCKET=${PUBLISH_BUCKET}
+  COMMIT=$(git rev-parse --verify HEAD)
+
+  GHC_VERSION=
+  GHC_PLATFORM=
+  DIST=
+  case "$BUILD" in
+    stack)
+        GHC_VERSION=$(stack ghc -- --numeric-version)
+        GHC_PLATFORM=$(stack ghc -- --print-target-platform)
+        DIST=$(stack path --dist-dir)
+      ;;
+    *)
+        GHC_VERSION=$(ghc --numeric-version)
+        GHC_PLATFORM=$(ghc --print-target-platform)
+        DIST=dist
+      ;;
+  esac
+
+  for B in $BINARIES; do
+    cp "${DIST}/build/${B}/${B}" "${B}"
+    tar cvzf "${B}.tar.gz" "${B}"
+    aws s3 cp "${B}.tar.gz" "${BUCKET}/${PROJECT}/${COMMIT}/${GHC_PLATFORM}/${GHC_VERSION}/${B}.tar.gz"
+  done
+
+fi


### PR DESCRIPTION
When master gets pushed, binaries will get published to S3.

Once I figure out staged builds, I can add a `release` job that runs on tag push. The `release` job will just fetch the tagged commit's binaries for given GHC/platform pairs.

Publishing 8.0.2 builds until I figure out how to make stack use 8.2.1.