### PR TITLE
Bump resolver to lts-9.8

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.6
+resolver: lts-9.8
 
 packages:
 - .


### PR DESCRIPTION
This is usually an innocuous change, but I like to open a PR to confirm that this doesn't break the build. If you're happy with this approach I can open and merge PRs like this myself in the future :smiley:.