### PR TITLE
Relax lower bound on `directory`

### DIFF
--- a/hgrep.cabal
+++ b/hgrep.cabal
@@ -34,7 +34,7 @@ executable hgrep
                      base                           >= 4.9           && < 4.11
                    , hgrep
                    , ansi-terminal                  >= 0.6.3         && < 0.8
-                   , directory                      >= 1.3           && < 1.4
+                   , directory                      >= 1.2           && < 1.4
                    , filepath                       >= 1.4           && < 1.5
                    , optparse-applicative           >= 0.13          && < 0.15
 


### PR DESCRIPTION
Without this the project does not compile on GHC 8.0.1.