### PR TITLE
Test with GHC 8.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,12 @@ jobs:
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
     <<: *DEFAULT
 
+  - stage: test
+    env: BUILD=cabal GHCVER=8.2.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+    <<: *DEFAULT
+
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   - stage: test
     env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,10 @@ environment:
       GHC: ghc-8.2.1
       GHC_URL: "https://downloads.haskell.org/~ghc/8.2.1/ghc-8.2.1-x86_64-unknown-mingw32.tar.xz"
       STACK_YAML: stack-8.2.1.yaml
+    -
+      GHC: ghc-8.2.2
+      GHC_URL: "https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-unknown-mingw32.tar.xz"
+      STACK_YAML: stack-8.2.2.yaml
 image: "Visual Studio 2015"
 install:
   - "mkdir c:\\ghc"

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,0 +1,14 @@
+resolver: nightly-2017-12-13
+
+packages:
+- .
+
+flags: {}
+
+extra-package-dbs: []
+
+nix:
+  enable: false
+  packages:
+    - pcre
+    - pkgconfig


### PR DESCRIPTION
I've left the `stack nightly` tests alone because the current nightly resolvers use GHC 8.2.2 anyway, which means that we are not currently testing Stack+8.2.1.